### PR TITLE
Update compatibility with Hexo 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-feed",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "homepage": "https://github.com/sergeyzwezdin/hexo-feed#readme",
     "peerDependencies": {
-        "hexo": "^4.2.0 || ^5.2.0 || ^6.1.0 || ^7.0.0",
+        "hexo": "^4.2.0 || ^5.2.0 || ^6.1.0 || ^7.0.0 || ^8.0.0",
         "chalk": "^4.1.0"
     },
     "dependencies": {},


### PR DESCRIPTION
same as https://github.com/sergeyzwezdin/hexo-feed/pull/7 but for Hexo 8.0.0.

https://johnnys.news was used for testing the feed and tags functionality to ensure everything was still working after the upgrade to Hexo 8.0.0